### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/codereview/library.py
+++ b/codereview/library.py
@@ -122,7 +122,7 @@ def show_reviewers(reviewer_list, arg=None):
 
 
 def format_approval_text(text, approval):
-  if approval == None:
+  if approval is None:
     return text
   if approval:
     return "<span class='approval'>" + text + "</span>"

--- a/codereview/models.py
+++ b/codereview/models.py
@@ -657,7 +657,7 @@ class Patch(ndb.Model):
 
     The value is cached.
     """
-    if self._property_changes != None:
+    if self._property_changes is not None:
       return self._property_changes
     self._property_changes = []
     match = re.search('^Property changes on.*\n'+'_'*67+'$', self.text,
@@ -776,7 +776,7 @@ class Patch(ndb.Model):
           msg = 'Bad content. Try to upload again.'
           logging.warn('Patch.get_content: %s', msg)
           raise FetchError(msg)
-        if content.is_uploaded and content.text == None:
+        if content.is_uploaded and content.text is None:
           msg = 'Upload in progress.'
           logging.warn('Patch.get_content: %s', msg)
           raise FetchError(msg)

--- a/codereview/views.py
+++ b/codereview/views.py
@@ -1233,7 +1233,7 @@ def upload_complete(request, patchset_id=None):
   errors = []
   if patchset is not None:
     query = models.Patch.query(
-        models.Patch.is_binary == False, models.Patch.status == None,
+        models.Patch.is_binary == False, models.Patch.status is None,
         ancestor=patchset.key)
     # All uploaded files have a status, any with status==None are missing.
     if query.count() > 0:
@@ -2100,7 +2100,7 @@ def _get_diff_table_rows(request, patch, context, column_width):
   if rows and rows[-1] is None:
     del rows[-1]
     # Get rid of content, which may be bad
-    if content.is_uploaded and content.text != None:
+    if content.is_uploaded and content.text is not None:
       # Don't delete uploaded content, otherwise get_content()
       # will fetch it.
       content.is_bad = True
@@ -3274,7 +3274,7 @@ def search(request):
 def repos(request):
   """/repos - Show the list of known Subversion repositories."""
   # Clean up garbage created by buggy edits
-  bad_branch_keys = models.Branch.query(models.Branch.owner == None).fetch(
+  bad_branch_keys = models.Branch.query(models.Branch.owner is None).fetch(
       100, keys_only=True)
   if bad_branch_keys:
     ndb.delete_multi(bad_branch_keys)
@@ -4281,7 +4281,7 @@ def yield_people_issue_to_update(day_to_process, issues, messages_looked_up):
       for user in figure_out_real_accounts(people_to_consider, people_caches):
         message_index, drive_by = search_relevant_first_email_for_user(
             issue_owner, messages, user, people_caches)
-        if (message_index == None or
+        if (message_index is None or
             ( drive_by and
               messages[message_index].sender == user and
               not any(m.sender == issue_owner

--- a/third_party/httplib2/__init__.py
+++ b/third_party/httplib2/__init__.py
@@ -371,7 +371,7 @@ def _entry_disposition(response_headers, request_headers):
                 freshness_lifetime = 0
         elif response_headers.has_key('expires'):
             expires = email.Utils.parsedate_tz(response_headers['expires'])
-            if None == expires:
+            if None is expires:
                 freshness_lifetime = 0
             else:
                 freshness_lifetime = max(0, calendar.timegm(expires) - date)
@@ -768,7 +768,7 @@ class ProxyInfo(object):
                 self.proxy_rdns, self.proxy_user, self.proxy_pass)
 
     def isgood(self):
-        return (self.proxy_host != None) and (self.proxy_port != None)
+        return (self.proxy_host is not None) and (self.proxy_port is not None)
 
     def applies_to(self, hostname):
         return not self.bypass_host(hostname)
@@ -1342,7 +1342,7 @@ class Http(object):
                     if response.has_key('location'):
                         location = response['location']
                         (scheme, authority, path, query, fragment) = parse_uri(location)
-                        if authority == None:
+                        if authority is None:
                             response['location'] = urlparse.urljoin(absolute_uri, location)
                     if response.status == 301 and method in ["GET", "HEAD"]:
                         response['-x-permanent-redirect-url'] = response['location']

--- a/third_party/httplib2/socks.py
+++ b/third_party/httplib2/socks.py
@@ -108,7 +108,7 @@ def wrapmodule(module):
     This will only work on modules that import socket directly into the namespace;
     most of the Python Standard Library falls into this category.
     """
-    if _defaultproxy != None:
+    if _defaultproxy is not None:
         module.socket.socket = socksocket
     else:
         raise GeneralProxyError((4, "no proxy specified"))
@@ -122,7 +122,7 @@ class socksocket(socket.socket):
 
     def __init__(self, family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0, _sock=None):
         _orgsocket.__init__(self, family, type, proto, _sock)
-        if _defaultproxy != None:
+        if _defaultproxy is not None:
             self.__proxy = _defaultproxy
         else:
             self.__proxy = (None, None, None, None, None, None)
@@ -167,7 +167,7 @@ class socksocket(socket.socket):
             hdrs.remove(endpt)
             host = host.split(" ")[1]
             endpt = endpt.split(" ")
-            if (self.__proxy[4] != None and self.__proxy[5] != None):
+            if (self.__proxy[4] is not None and self.__proxy[5] is not None):
                 hdrs.insert(0, self.__getauthheader())
             hdrs.insert(0, "Host: %s" % host)
             hdrs.insert(0, "%s http://%s%s %s" % (endpt[0], host, endpt[1], endpt[2]))
@@ -201,7 +201,7 @@ class socksocket(socket.socket):
         Negotiates a connection through a SOCKS5 server.
         """
         # First we'll send the authentication packages we support.
-        if (self.__proxy[4]!=None) and (self.__proxy[5]!=None):
+        if (self.__proxy[4]is notNone) and (self.__proxy[5]is notNone):
             # The username/password details were supplied to the
             # setproxy method so we support the USERNAME/PASSWORD
             # authentication (in addition to the standard none).
@@ -283,7 +283,7 @@ class socksocket(socket.socket):
             raise GeneralProxyError((1,_generalerrors[1]))
         boundport = struct.unpack(">H", self.__recvall(2))[0]
         self.__proxysockname = (boundaddr, boundport)
-        if ipaddr != None:
+        if ipaddr is not None:
             self.__proxypeername = (socket.inet_ntoa(ipaddr), destport)
         else:
             self.__proxypeername = (destaddr, destport)
@@ -325,7 +325,7 @@ class socksocket(socket.socket):
         # Construct the request packet
         req = struct.pack(">BBH", 0x04, 0x01, destport) + ipaddr
         # The username parameter is considered userid for SOCKS4
-        if self.__proxy[4] != None:
+        if self.__proxy[4] is not None:
             req = req + self.__proxy[4]
         req = req + chr(0x00).encode()
         # DNS name if remote resolving is required
@@ -350,7 +350,7 @@ class socksocket(socket.socket):
                 raise Socks4Error((94, _socks4errors[4]))
         # Get the bound address/port
         self.__proxysockname = (socket.inet_ntoa(resp[4:]), struct.unpack(">H", resp[2:4])[0])
-        if rmtrslv != None:
+        if rmtrslv is not None:
             self.__proxypeername = (socket.inet_ntoa(ipaddr), destport)
         else:
             self.__proxypeername = (destaddr, destport)
@@ -366,7 +366,7 @@ class socksocket(socket.socket):
             addr = destaddr
         headers =  ["CONNECT ", addr, ":", str(destport), " HTTP/1.1\r\n"]
         headers += ["Host: ", destaddr, "\r\n"]
-        if (self.__proxy[4] != None and self.__proxy[5] != None):
+        if (self.__proxy[4] is not None and self.__proxy[5] is not None):
                 headers += [self.__getauthheader(), "\r\n"]
         headers.append("\r\n")
         self.sendall("".join(headers).encode())
@@ -402,28 +402,28 @@ class socksocket(socket.socket):
         if (not type(destpair) in (list,tuple)) or (len(destpair) < 2) or (not isinstance(destpair[0], basestring)) or (type(destpair[1]) != int):
             raise GeneralProxyError((5, _generalerrors[5]))
         if self.__proxy[0] == PROXY_TYPE_SOCKS5:
-            if self.__proxy[2] != None:
+            if self.__proxy[2] is not None:
                 portnum = self.__proxy[2]
             else:
                 portnum = 1080
             _orgsocket.connect(self, (self.__proxy[1], portnum))
             self.__negotiatesocks5(destpair[0], destpair[1])
         elif self.__proxy[0] == PROXY_TYPE_SOCKS4:
-            if self.__proxy[2] != None:
+            if self.__proxy[2] is not None:
                 portnum = self.__proxy[2]
             else:
                 portnum = 1080
             _orgsocket.connect(self,(self.__proxy[1], portnum))
             self.__negotiatesocks4(destpair[0], destpair[1])
         elif self.__proxy[0] == PROXY_TYPE_HTTP:
-            if self.__proxy[2] != None:
+            if self.__proxy[2] is not None:
                 portnum = self.__proxy[2]
             else:
                 portnum = 8080
             _orgsocket.connect(self,(self.__proxy[1], portnum))
             self.__negotiatehttp(destpair[0], destpair[1])
         elif self.__proxy[0] == PROXY_TYPE_HTTP_NO_TUNNEL:
-            if self.__proxy[2] != None:
+            if self.__proxy[2] is not None:
                 portnum = self.__proxy[2]
             else:
                 portnum = 8080
@@ -432,7 +432,7 @@ class socksocket(socket.socket):
                 self.__negotiatehttp(destpair[0],destpair[1])
             else:
                 self.__httptunnel = False
-        elif self.__proxy[0] == None:
+        elif self.__proxy[0] is None:
             _orgsocket.connect(self, (destpair[0], destpair[1]))
         else:
             raise GeneralProxyError((4, _generalerrors[4]))

--- a/upload.py
+++ b/upload.py
@@ -1207,11 +1207,11 @@ class VersionControlSystem(object):
         base_content = None
         file_id_str = file_id_str[file_id_str.rfind("_") + 1:]
       file_id = int(file_id_str)
-      if base_content != None:
+      if base_content is not None:
         t = thread_pool.apply_async(UploadFile, args=(filename,
             file_id, base_content, is_binary, status, True))
         threads.append(t)
-      if new_content != None:
+      if new_content is not None:
         t = thread_pool.apply_async(UploadFile, args=(filename,
             file_id, new_content, is_binary, status, False))
         threads.append(t)
@@ -2297,7 +2297,7 @@ def GuessVCSName(options):
     detection routine, or None if there is nothing interesting.
   """
   for attribute, value in options.__dict__.iteritems():
-    if attribute.startswith("p4") and value != None:
+    if attribute.startswith("p4") and value is not None:
       return (VCS_PERFORCE, None)
 
   def RunDetectCommand(vcs_type, command):
@@ -2319,26 +2319,26 @@ def GuessVCSName(options):
   # Try running it, but don't die if we don't have hg installed.
   # NOTE: we try Mercurial first as it can sit on top of an SVN working copy.
   res = RunDetectCommand(VCS_MERCURIAL, ["hg", "root"])
-  if res != None:
+  if res is not None:
     return res
 
   # Subversion from 1.7 has a single centralized .svn folder
   # ( see http://subversion.apache.org/docs/release-notes/1.7.html#wc-ng )
   # That's why we use 'svn info' instead of checking for .svn dir
   res = RunDetectCommand(VCS_SUBVERSION, ["svn", "info"])
-  if res != None:
+  if res is not None:
     return res
 
   # Git has a command to test if you're in a git tree.
   # Try running it, but don't die if we don't have git installed.
   res = RunDetectCommand(VCS_GIT, ["git", "rev-parse",
                                    "--is-inside-work-tree"])
-  if res != None:
+  if res is not None:
     return res
 
   # detect CVS repos use `cvs status && $? == 0` rules
   res = RunDetectCommand(VCS_CVS, ["cvs", "status"])
-  if res != None:
+  if res is not None:
     return res
 
   return (VCS_UNKNOWN, None)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:rietveld?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:rietveld?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
